### PR TITLE
Remove incorrect trailing commas

### DIFF
--- a/META.info
+++ b/META.info
@@ -6,7 +6,6 @@
     "source-url" : "git://github.com/perlpilot/p6-Math-Trig.git",
     "depends" : [ ],
     "provides" : {
-      "Math::Trig" : "Math-Trig/lib/Math/Trig.pm",
-    },
+      "Math::Trig" : "Math-Trig/lib/Math/Trig.pm"
+    }
 }
-


### PR DESCRIPTION
The trailing commas in the `provides` hash are invalid JSON.  This change
corrects the issue.
