### PR TITLE
Correct priming of great-circle-waypoint

### DIFF
--- a/lib/Math/Trig.pm
+++ b/lib/Math/Trig.pm
@@ -128,7 +128,7 @@ sub great-circle-waypoint($theta0, $phi0, $theta1, $phi1, $point = 0.5) is expor
     return ($theta, $phi);
 }
 
-our &great-circle-midpoint is export(:great-circle) = &great-circle-waypoint.assuming(:point(0.5));
+our &great-circle-midpoint is export(:great-circle) = &great-circle-waypoint.assuming(*,*,*,*,0.5);
 
 sub great-circle-destination( $theta0, $phi0, $dir0, $dst ) is export(:great-circle)
 {


### PR DESCRIPTION
Current code seems to be trying to set a positional using a named value.  That feature was discarded a while ago.

The .assuming code was recently rewritten to properly support \* to skip positional paremeters, per spec.

This updates the definition of great-circle-midpoint to use this syntax and correctly remove the optional last parameter, after which t/04 passes tests 16 and 17.

There is still a failing test in t/03
